### PR TITLE
Fixed a `ripgrep` problematic argument in TODOs

### DIFF
--- a/lua/sidebar-nvim/builtin/todos.lua
+++ b/lua/sidebar-nvim/builtin/todos.lua
@@ -57,7 +57,6 @@ local function async_update(ctx)
     if vim.fn.executable("rg") == 1 then
         cmd = "rg"
         args = {
-            "--ignore-files",
             "--no-hidden",
             "--column",
             "--only-matching",


### PR DESCRIPTION
The argument `--ignore-files` in ripgrep (`rg`) was giving some errors (seems that dont exists, it is not even in the documentation).

Example of test:
![image](https://user-images.githubusercontent.com/21228945/151064505-62b31a1f-bd1f-4507-a72a-f53ead60dce0.png)
(and this breaks the TODOs panel)

If the pourpose was to ignore git files (from .gitignore), ripgrep ignores those files by [default](https://github.com/BurntSushi/ripgrep)
> By default, ripgrep will respect gitignore rules and automatically skip hidden files/directories and binary files

The closest argument similar to `--ignore-files` is `--ignore-file`, but is just an argument that recives a specific location to be ignored on the search. Seems to be not necesary here.

So tell me if you had consider any other variation of ripgrep. Or if that was a mistake, removing that arg is the solution I found after a while debugging.

Without that arg, `rg` runs well:
![image](https://user-images.githubusercontent.com/21228945/151064714-2c9fce36-93ce-438c-9f42-dc17944b4944.png)

The Sidebar / The arguments of the spawn command
![image](https://user-images.githubusercontent.com/21228945/151064810-4152be14-cbad-40be-890b-0b3925a8c93d.png)
