### PR TITLE
LSP: Support SymbolInformation[] response type

### DIFF
--- a/lua/sidebar-nvim/builtin/symbols.lua
+++ b/lua/sidebar-nvim/builtin/symbols.lua
@@ -35,7 +35,21 @@ local kinds = {
     { text = "+ ", hl = "TSOperator" },
     { text = "𝙏 ", hl = "TSParameter" },
 }
+
+local function keep_normalized_symbols(symbols)
+    local symbols_ = {}
+    for _, symbol in ipairs(symbols) do
+        symbol.range = symbol.range or (symbol.location or {}).range
+        -- Filter out symbols that don't support range or location.range
+        if symbol.range then
+            table.insert(symbols_, symbol)
+        end
+    end
+    return symbols_
+end
+
 local function build_loclist(filepath, loclist_items, symbols, level)
+    symbols = keep_normalized_symbols(symbols)
     table.sort(symbols, function(a, b)
         return a.range.start.line < b.range.start.line
     end)
@@ -47,7 +61,7 @@ local function build_loclist(filepath, loclist_items, symbols, level)
             left = {
                 { text = string.rep(" ", level) .. kind.text, hl = kind.hl },
                 { text = symbol.name .. " ", hl = "SidebarNvimSymbolsName" },
-                { text = symbol.detail, hl = "SidebarNvimSymbolsDetail" },
+                { text = symbol.detail or "", hl = "SidebarNvimSymbolsDetail" },
             },
             right = {},
             data = { symbol = symbol, filepath = filepath },

--- a/lua/sidebar-nvim/renderer.lua
+++ b/lua/sidebar-nvim/renderer.lua
@@ -115,6 +115,15 @@ local function get_lines_and_hl(sections_data)
     return lines, hl, section_line_indexes
 end
 
+local function sanitize_lines(lines)
+    local lines_ = {}
+    for _, line_ in ipairs(lines) do
+        local line = string.gsub(line_, '%s+', ' ')
+        table.insert(lines_, line)
+    end
+    return lines_
+end
+
 function M.draw(sections_data)
     return profile.run("view.render", function()
         if not api.nvim_buf_is_loaded(view.View.bufnr) then
@@ -127,6 +136,7 @@ function M.draw(sections_data)
         end
 
         local lines, hl, section_line_indexes = get_lines_and_hl(sections_data)
+        lines = sanitize_lines(lines)
 
         api.nvim_buf_set_option(view.View.bufnr, "modifiable", true)
         api.nvim_buf_set_lines(view.View.bufnr, 0, -1, false, lines)


### PR DESCRIPTION
Some language servers (like [cssls][cssls]) don't respond to `"textDocument/documentSymbol"` with the type `DocumentSymbol[]`, but instead `SymbolInformation[]`.

This is a flat list of symbols in contrast to a hierarchy of symbols with `children` properties. ​There are other subtle differences, like the lack of a `detail` field, as well the range living in `location.range` instead of `range`. [See here in the LSP spec for details about the two types][docsyms].

[cssls]: https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#cssls
[docsyms]: https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#textDocument_documentSymbol

This code was put together quickly, so I'm not sure how well it holds up. I found [vim.lsp.utils.symbols_to_items()](https://github.com/neovim/neovim/blob/master/runtime/lua/vim/lsp/util.lua#L1669), but it seems to lose `name` information that's used to build the resulting lines.

Speaking of lines, I ran into a strange issue in which newlines were appearing in the resulting strings, causing `nvim_buf_set_lines` to fail. Let me know if I'm on the right track here, and thank you for your work on such an awesome plugin!