### PR TITLE
fix: check if timer is nil before destroy

### DIFF
--- a/lua/sidebar-nvim/lib.lua
+++ b/lua/sidebar-nvim/lib.lua
@@ -148,9 +148,11 @@ end
 function M.destroy()
     view.close()
 
-    M.timer:stop()
-    M.timer:close()
-    M.timer = nil
+    if M.timer ~= nil then
+        M.timer:stop()
+        M.timer:close()
+        M.timer = nil
+    end
 
     view._wipe_rogue_buffer()
 end


### PR DESCRIPTION
Check if timer is nil before destroy timer. This can be tested by the following steps:

1. `sleep 1; vim +q`
2. Quickly switch to other screen like switching tmux window to make vim not showing on the screen.

Before this fix, vim will print following error log:
```
Error detected while processing VimLeavePre Autocommands for "*":
E5108: Error executing lua .../pack/packer/start/sidebar.nvim/lua/sidebar-nvim/lib.lua:151: attempt to index field 'timer' (a nil value)
stack traceback:
        .../pack/packer/start/sidebar.nvim/lua/sidebar-nvim/lib.lua:151: in function 'destroy'
```