### PR TITLE
fix: wrap call to devicons in schedule_wrap

### DIFF
--- a/lua/sidebar-nvim/builtin/git.lua
+++ b/lua/sidebar-nvim/builtin/git.lua
@@ -77,7 +77,9 @@ local function parse_git_status(group, line)
         local fileicon = ""
 
         if has_devicons and devicons.has_loaded() then
-            local icon = devicons.get_icon_color(filepath, extension)
+            local icon = vim.schedule_wrap(function()
+                return devicons.get_icon_color(filepath, extension)
+            end)()
             if icon then
                 fileicon = icon
             end


### PR DESCRIPTION
This is done so we can avoid the `nvim_get_hl must not be called in a lua loop callback` error. Should close #101